### PR TITLE
Add init and dispose lifecycle methods to Systems

### DIFF
--- a/src/internals/system-manager.ts
+++ b/src/internals/system-manager.ts
@@ -50,6 +50,7 @@ export class SystemManager<WorldType extends World> {
     groupInstance.add(system);
     groupInstance.sort();
     this._systems.set(Class, system);
+    if (system.init) system.init();
     return this;
   }
 
@@ -74,6 +75,7 @@ export class SystemManager<WorldType extends World> {
       // somewhere else.
       this._groups.splice(this._groups.indexOf(group), 1);
     }
+    if (system.dispose) system.dispose();
     // Deletes system entry.
     this._systems.delete(Class);
   }

--- a/src/system.ts
+++ b/src/system.ts
@@ -142,6 +142,16 @@ export abstract class System<WorldType extends World = World> {
    */
   public abstract execute(delta: number): void;
 
+  /**
+   * Called when the System is registered in a World
+   */
+  public init?(): void;
+
+  /**
+   * Called when the System is removed from a World
+   */
+  public dispose?(): void;
+
   /** Returns the group in which this system belongs */
   public get group(): SystemGroup<WorldType> {
     return this._group;

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -32,3 +32,15 @@ export class FooBarSystem extends System {
   };
   execute() {}
 }
+
+export function spy() {
+  function proxy(...args: unknown[]) {
+    proxy.calls.push(args);
+    proxy.called = true;
+  }
+
+  proxy.calls = [] as unknown[];
+  proxy.called = false;
+
+  return proxy;
+}

--- a/test/unit/world.test.ts
+++ b/test/unit/world.test.ts
@@ -1,12 +1,13 @@
 import test from 'ava';
 import { SystemGroup } from '../../src/system-group.js';
 import { System } from '../../src/system.js';
-
 import { World } from '../../src/world.js';
+import { spy } from './utils.js';
 
 test('World > System > register', (t) => {
   class MySystem extends System {
     execute() {}
+    init = spy();
   }
   const world = new World();
   world.register(MySystem);
@@ -14,6 +15,7 @@ test('World > System > register', (t) => {
 
   t.true(!!sys);
   t.is(sys.group.constructor, SystemGroup);
+  t.true(sys.init.called);
 });
 
 test('World > System > register with group', (t) => {
@@ -56,6 +58,7 @@ test('World > SystemGroup > retrieve', (t) => {
 test('World > System > unregister', (t) => {
   class MySystem extends System {
     execute() {}
+    dispose = spy();
   }
   class MyGroup extends SystemGroup {}
 
@@ -72,4 +75,5 @@ test('World > System > unregister', (t) => {
   t.false(!!world.system(MySystem)!);
   t.is(group['_systems'].indexOf(system), -1);
   t.is(world.group(MyGroup), undefined);
+  t.true(system.dispose.called);
 });


### PR DESCRIPTION
I had some free time today and have been playing around with threejs - I like the direction your heading.

I added two lifecycle methods - `init` and `dispose` - to the System class and added basic tests cases for each.